### PR TITLE
FEAT: Add dolpha3 (draft)

### DIFF
--- a/bt/backtest/strats/dolpha3.py
+++ b/bt/backtest/strats/dolpha3.py
@@ -1,0 +1,165 @@
+from decimal import Decimal
+from typing import Optional, Dict, Any, List, Tuple
+from datetime import datetime, timedelta
+import pandas as pd
+import numpy as np
+
+from backtest.strategies import StreamingStrategy, TradingContext
+from backtest.models import Signal
+from backtest.types import ActionType, SignalType
+from indicators.indicators import (
+    SMA, EMA, RSI, MACD, BollingerBands,
+    SupportResistance, FibonacciLevels, MAAnalyzer
+)
+from backtest.logger import get_logger
+
+
+class Dolpha3Strategy(StreamingStrategy):
+    """
+    STRATEGY OVERVIEW:
+    ==================
+    A counter-trend trading strategy that identifies oversold conditions across multiple timeframes
+    and enters positions with progressive martingale sizing. Exits are managed through 
+    Fibonacci retracement levels for optimal profit taking.
+    
+    ENTRY CONDITIONS:
+    =================
+    1. TREND FILTER (Higher Timeframes)
+       - 1H & 4H MACD golden cross with upward momentum
+       - Daily MA arrangement: MA112 > MA224 > MA448 (bullish structure)
+       - MAs within 20% of each other (not overextended)
+    
+    2. OVERSOLD SIGNAL (All timeframes must confirm)
+       - RSI(3m) < 30
+       - RSI(15m) < 30
+       - RSI(30m) < 30
+       - RSI(1h) < 30
+    
+    3. SUPPORT CONFIRMATION
+       - Price bouncing off 3m MA360 (2+ touches required)
+       - Price above 30m MA60 support
+       - Price above 1h MA60 support
+       - Close must be above support level for confirmation
+    
+    4. ENTRY TRIGGER
+       - All conditions met on 15-minute bar close
+       - Prevents mid-bar false signals
+    
+    POSITION SIZING:
+    ================
+    - Initial Entry: 1% of total capital
+    - Scale-in Strategy: 1.4x multiplier per level
+    - Maximum 10 entries (uses ~69.8% of capital)
+    - Add positions every -5% from average price
+    - Martingale approach for faster breakeven recovery
+    
+    EXIT STRATEGY:
+    ==============
+    1. STANDARD MODE (Conservative)
+       - Fibonacci 0.382: Exit 50% of position
+       - Fibonacci 0.500: Exit remaining 50%
+    
+    2. AGGRESSIVE MODE (Scaled exits)
+       - Fibonacci 0.382: Exit 50%
+       - Fibonacci 0.500: Exit 25%
+       - Fibonacci 0.786: Exit final 25%
+    
+    3. BREAKEVEN EXIT
+       - After averaging down, exit 100% at breakeven
+       - Priority over Fibonacci targets
+    
+    RISK MANAGEMENT:
+    ================
+    - Stop Loss: -15% from lowest entry (after 3rd buy)
+    - With 10x leverage: Effectively -1.5% portfolio risk
+    - Daily Stop: 3 stop losses = 24hr trading halt
+    - Market Regime: Disable in strong trends/one-way markets
+    """
+    
+    def __init__(
+        self,
+        data: Any,  # MultiTimeframeData object
+        lookback_periods: int = 500,
+        position_size_pct: float = 0.01,  # 1% initial position
+        scale_multiplier: float = 1.4,  # Martingale multiplier
+        max_entries: int = 10,
+        add_threshold: float = -0.05,  # Add every -5%
+        stop_loss_pct: float = -0.15,  # -15% from lowest entry
+        daily_stop_limit: int = 3,
+        use_aggressive_exits: bool = False
+    ):
+        super().__init__(lookback_periods=lookback_periods)
+        
+        self.data = data
+        self.position_size_pct = Decimal(str(position_size_pct))
+        self.scale_multiplier = Decimal(str(scale_multiplier))
+        self.max_entries = max_entries
+        self.add_threshold = Decimal(str(add_threshold))
+        self.stop_loss_pct = Decimal(str(stop_loss_pct))
+        self.daily_stop_limit = daily_stop_limit
+        self.use_aggressive_exits = use_aggressive_exits
+        
+        # State tracking
+        self.entry_count = 0
+        self.entry_prices: List[Decimal] = []
+        self.entry_sizes: List[Decimal] = []
+        self.avg_entry_price = Decimal("0")
+        self.lowest_entry_price = Decimal("0")
+        self.highest_price_since_entry = Decimal("0")
+        self.support_touch_count: Dict[str, int] = {}
+        self.daily_stops = 0
+        self.last_stop_date = None
+        self.trading_enabled = True
+        
+        # Fibonacci levels for exits
+        self.fib_levels = [0.382, 0.5, 0.618, 0.786]
+        self.fib_targets: Dict[float, Decimal] = {}
+        
+        # Technical indicator values
+        self.indicators: Dict[str, Any] = {}
+        
+        self.logger = get_logger(__name__)
+    
+    def reset_state(self) -> None:
+        """Reset all strategy state variables"""
+        super().reset_state()
+        self.entry_count = 0
+        self.entry_prices.clear()
+        self.entry_sizes.clear()
+        self.avg_entry_price = Decimal("0")
+        self.lowest_entry_price = Decimal("0")
+        self.highest_price_since_entry = Decimal("0")
+        self.support_touch_count.clear()
+        self.daily_stops = 0
+        self.last_stop_date = None
+        self.trading_enabled = True
+        self.fib_targets.clear()
+        self.indicators.clear()
+    
+    def update_indicators(self, context: TradingContext) -> None:
+        """Calculate all required indicators across timeframes"""
+        # This will be implemented with actual indicator calculations
+        pass
+    
+    def check_entry_conditions(self, context: TradingContext) -> bool:
+        """Check if all entry conditions are met"""
+        # This will be implemented with actual condition checks
+        return False
+    
+    def calculate_position_size(self, entry_number: int, capital: Decimal) -> Decimal:
+        """Calculate position size using martingale scaling"""
+        base_size = capital * self.position_size_pct
+        if entry_number == 1:
+            return base_size
+        return base_size * (self.scale_multiplier ** (entry_number - 1))
+    
+    def update_fibonacci_targets(self, low: Decimal, high: Decimal) -> None:
+        """Calculate Fibonacci retracement levels for profit targets"""
+        diff = high - low
+        for level in self.fib_levels:
+            self.fib_targets[level] = low + (diff * Decimal(str(level)))
+    
+    def process_bar(self, context: TradingContext) -> Optional[Signal]:
+        """Main strategy logic - process each bar and generate signals"""
+        # This will be implemented with full strategy logic
+        return None

--- a/bt/main/main.py
+++ b/bt/main/main.py
@@ -40,16 +40,16 @@ def main(strategy_choice=2):
                 .add(symbol, TimeFrame.H1, date_range))
         strategy = GoldenCrossStrategy(data=data)
         strategy_name = "GoldenCrossStrategy"
-    elif choice == "2":
+    else:
         data = MultiTimeframeData(loader).add(symbol, TimeFrame.D1, date_range)
         strategy = GoldenCrossOnlyStrategy()
         strategy_name = "GoldenCrossOnlyStrategy"
     
     engine = BacktestEngine(
         transaction_cost=TransactionCost(
-            maker_fee=Decimal("0.00001"),
-            taker_fee=Decimal("0.00001"),
-            slippage=Decimal("0.00001")
+            maker_fee=Decimal("0.0001"),
+            taker_fee=Decimal("0.0001"),
+            slippage=Decimal("0.0001")
         )
     )
     
@@ -57,10 +57,14 @@ def main(strategy_choice=2):
     session_id = f"backtest_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
     storage.initialize_session(session_id)
     
+    if choice == "1":
+        ohlcv_data = data["3m"]
+    else:
+        ohlcv_data = data["1d"]
     
     result = engine.run_backtest(
         strategy=strategy,
-        ohlcv_data=data["1d"],
+        ohlcv_data=ohlcv_data,
         initial_capital=Decimal("100000000"),
         symbol=f"{symbol.base}{symbol.quote}",
         storage=storage
@@ -74,7 +78,7 @@ def main(strategy_choice=2):
     
     generate_plots(
         result=result,
-        benchmark_data=data["1d"],
+        benchmark_data=ohlcv_data,
         strategy_name=strategy_name,
         output_dir="bt_results",
         show_plots=False,

--- a/bt/main/save.py
+++ b/bt/main/save.py
@@ -11,7 +11,7 @@ def load_trades(session_id: str, fallback_df: pd.DataFrame = None) -> pd.DataFra
         storage = TradeStorage(base_dir="bt_results")
         trades = storage.load_trades(session_id)
         if not trades:
-            return fallback_df or pd.DataFrame()
+            return fallback_df if fallback_df is not None else pd.DataFrame()
         
         data = []
         for i in range(0, len(trades), 2):
@@ -32,7 +32,7 @@ def load_trades(session_id: str, fallback_df: pd.DataFrame = None) -> pd.DataFra
         return df
     except Exception as e:
         print(f"Storage load error: {e}")
-        return fallback_df or pd.DataFrame()
+        return fallback_df if fallback_df is not None else pd.DataFrame()
 
 
 def get_periods_per_year(equity_curve: pd.DataFrame) -> int:


### PR DESCRIPTION
# 📑 매매 전략 정리

## 1. 추세 필터
- **대추세 확인**
  - 1시간봉, 4시간봉에서 **MACD 골든크로스** 및 우상향
- **이평선 배열**
  - 112 > 224 > 448 순 정배열
  - 이평선 간 **이격도 20% 이내**

---

## 2. RSI 조건
- 적용 차트: 3분봉, 15분봉, 30분봉, 1시간봉
- 조건: 모든 봉의 **RSI ≤ 30**일 때 매수 고려

---

## 3. 이평선 지지 조건
- 지지선 판정:
  - 3분봉 360일선
  - 30분봉 60일선
  - 1시간봉 60일선
- **판정 방식**
  - 해당 이평선을 **2회 이상 터치 후**
  - 종가가 이평선 위에 있을 때 ‘지지’ 인정

---

## 4. 진입 신호
- **15분봉 마감 기준**
- 모든 조건 충족 시 진입

---

## 5. 포지션 크기 및 분할 매수
- 초기 진입: **총자산 1%**, 10배 Cross 레버리지
- 추가 진입: 매회 **1.4배 증액**, 최대 10회 분할  
  → 총 약 **69.8% 자산 사용**
- **물타기 조건**
  - 5% 가격 하락 단위로 추가 매수
  - 레버리지 10배 기준: 실물 가격 0.5% 하락 단위

---

## 6. 익절 전략
- **일반 익절**
  - 피보나치 0.382: 50% 청산
  - 피보나치 0.5: 50% 청산
- **공격적 익절 (조건 발생 시)**
  - 0.382: 50% 청산
  - 0.5: 25% 청산
  - 0.786: 25% 청산
- **추가 원칙**
  - 물타기 후 본전 도달 시 전량 청산
  - 불타기 금지
  - 잔여 물량은 트레일링 스탑 적용

---

## 7. 손절 전략
- 3차 매수까지 진행 후,
  - 최저 매수가 대비 **15% 추가 하락 시 전량 손절**
- 레버리지 10배 기준: 실물 가격 약 **1.5% 하락**

---

## 8. 리스크 관리
- 하루 손절 **3회 발생 시 24시간 매매 중지**
- 대시세·원웨이 장세 시 매매 중지
