### PR TITLE
ADJ: Adjust indicators to polars, numba

### DIFF
--- a/bt/backtest/strategies.py
+++ b/bt/backtest/strategies.py
@@ -38,7 +38,7 @@ class StreamingStrategy(ABC):
         self.name = name
         self.parameters = parameters or {}
         self.lookback_periods = lookback_periods
-        self._trade_history: deque = deque(maxlen=1000)  # Store actual trade results
+        self._trade_history: deque = deque(maxlen=1000)
         self._indicator_cache: Dict[str, Any] = {}
         self._state: Dict[str, Any] = {}
 
@@ -73,20 +73,16 @@ class StreamingStrategy(ABC):
 
 
     def record_signal(self, timestamp: datetime, signal: Signal) -> None:
-        """Backward compatibility - just pass for now"""
         pass
 
     def record_trade(self, timestamp: datetime, trade_data: Dict[str, Any]) -> None:
-        """Record actual trade execution data"""
         self._trade_history.append((timestamp, trade_data))
 
     @property
     def signals_history(self) -> List:
-        """Backward compatibility - return empty list"""
         return []
 
     @property
     def trade_history(self) -> List[Tuple[datetime, Dict[str, Any]]]:
-        """Get actual trade execution history"""
         return list(self._trade_history)
 

--- a/bt/backtest/strats/dolpha1.py
+++ b/bt/backtest/strats/dolpha1.py
@@ -9,7 +9,7 @@ from backtest.types import ActionType, Signal
 from backtest.timeframe import MultiTimeframeData
 from backtest.logger import get_logger
 from backtest.strategies import StreamingStrategy, TradingContext
-from indicators.indicators import MovingAverage
+from indicators.indicators import SMA
 
 
 class GoldenCrossStrategy(StreamingStrategy):
@@ -84,13 +84,13 @@ class GoldenCrossStrategy(StreamingStrategy):
     def _initialize_indicators(self):
         # NOTE: Daily MA indicators
         self._daily_ma_indicators = {
-            period: MovingAverage(name=f"ma_{period}", length=period)
+            period: SMA(name=f"ma_{period}", length=period)
             for period in self.parameters["ma_periods"]["daily"]
         }
         
         # NOTE: MTF MA indicators
         self._mtf_ma_indicators = {
-            f"{tf}_{period}": MovingAverage(name=f"ma_{tf}_{period}", length=period)
+            f"{tf}_{period}": SMA(name=f"ma_{tf}_{period}", length=period)
             for tf, period in self.MTF_PERIODS.items()
         }
 

--- a/bt/backtest/strats/dolpha2.py
+++ b/bt/backtest/strats/dolpha2.py
@@ -7,7 +7,7 @@ from collections import deque
 from backtest.types import ActionType, Signal
 from backtest.logger import get_logger
 from backtest.strategies import StreamingStrategy, TradingContext
-from indicators.indicators import MovingAverage
+from indicators.indicators import SMA
 
 
 class GoldenCrossOnlyStrategy(StreamingStrategy):
@@ -67,7 +67,7 @@ class GoldenCrossOnlyStrategy(StreamingStrategy):
     def _initialize_indicators(self):
         # NOTE: Daily MA indicators
         self._daily_ma_indicators = {
-            period: MovingAverage(name=f"ma_{period}", length=period)
+            period: SMA(name=f"ma_{period}", length=period)
             for period in self.parameters["ma_periods"]
         }
 

--- a/bt/indicators/__init__.py
+++ b/bt/indicators/__init__.py
@@ -1,17 +1,27 @@
 from .indicators import (
     IchimokuCloud,
     VolumeProfile,
-    MovingAverage,
+    SMA,
+    EMA,
     RSI,
     MACD,
+    BollingerBands,
+    SupportResistance,
+    FibonacciLevels,
+    MAAnalyzer,
     IndicatorProcessor,
 )
 
 __all__ = [
     "IchimokuCloud",
     "VolumeProfile",
-    "MovingAverage",
+    "SMA",
+    "EMA",
     "RSI",
     "MACD",
+    "BollingerBands",
+    "SupportResistance",
+    "FibonacciLevels",
+    "MAAnalyzer",
     "IndicatorProcessor",
 ]

--- a/bt/indicators/indicators.py
+++ b/bt/indicators/indicators.py
@@ -1,137 +1,384 @@
 import numpy as np
 import pandas as pd
+import numba as nb
+import polars as pl
 from typing import List, Dict
-
+from abc import ABC, abstractmethod
 from core.protocols import TechnicalIndicator
 
 
-class IchimokuCloud:
-    def __init__(self, name: str, tenkan: int = 9, kijun: int = 26, senkou: int = 52):
+class BaseIndicator(ABC):
+    
+    def __init__(self, name: str):
         self.name = name
+    
+    @abstractmethod
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        pass
+    
+    def calculate(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        return self._compute(ohlcv)
+    
+    def reset(self) -> None:
+        pass
+
+
+class RollingWindowIndicator(BaseIndicator):    
+    def __init__(self, name: str, window: int):
+        super().__init__(name)
+        self.window = window
+
+
+class IchimokuCloud(BaseIndicator):
+    def __init__(self, name: str, tenkan: int = 9, kijun: int = 26, senkou: int = 52):
+        super().__init__(name)
         self._tenkan = tenkan
         self._kijun = kijun
         self._senkou = senkou
 
-    def calculate(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
         high = ohlcv["high"]
         low = ohlcv["low"]
         close = ohlcv["close"]
         
-        # NOTE: Conversion Line (Tenkan-sen)
         tenkan_high = high.rolling(window=self._tenkan).max()
         tenkan_low = low.rolling(window=self._tenkan).min()
         conversion_line = (tenkan_high + tenkan_low) / 2
         
-        # NOTE: Base Line (Kijun-sen)
         kijun_high = high.rolling(window=self._kijun).max()
         kijun_low = low.rolling(window=self._kijun).min()
         base_line = (kijun_high + kijun_low) / 2
         
-        # NOTE: Leading Span A (Senkou Span A)
         leading_span_a = ((conversion_line + base_line) / 2).shift(self._kijun)
         
-        # NOTE: Leading Span B (Senkou Span B)
         senkou_high = high.rolling(window=self._senkou).max()
         senkou_low = low.rolling(window=self._senkou).min()
         leading_span_b = ((senkou_high + senkou_low) / 2).shift(self._kijun)
         
-        # NOTE: Lagging Span (Chikou Span)
         lagging_span = close.shift(-self._kijun)
         
-        df = pd.DataFrame({
+        return pd.DataFrame({
             f"{self.name}_conversion_line": conversion_line,
             f"{self.name}_base_line": base_line,
             f"{self.name}_leading_span_a": leading_span_a,
             f"{self.name}_leading_span_b": leading_span_b,
             f"{self.name}_lagging_span": lagging_span,
         })
-        
-        return df
 
 
-class VolumeProfile:
+class VolumeProfile(BaseIndicator):
     def __init__(self, name: str, bins: int = 20):
-        self.name = name
+        super().__init__(name)
         self._bins = bins
 
-    def calculate(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
-        bins = pd.cut(ohlcv["close"], bins=self._bins,
-                      labels=False, right=False)
-        vp = ohlcv.groupby(bins)["volume"].sum()
-
-        poc_level = vp.idxmax()
-        poc_price_range = ohlcv["close"][bins == poc_level].agg(["min", "max"])
-        poc = (poc_price_range["min"] + poc_price_range["max"]) / 2
-
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        temp = pl.from_pandas(ohlcv[["close", "volume"]])
+        
+        close_min = temp["close"].min()
+        close_max = temp["close"].max()
+        close_range = close_max - close_min
+        
+        if close_range == 0:
+            poc = close_min
+        else:
+            df_with_bins = temp.with_columns(
+                ((pl.col("close") - close_min) / close_range * self._bins).floor().alias("bin")
+            )
+            
+            volume_by_bin = df_with_bins.group_by("bin").agg(
+                pl.col("volume").sum().alias("total_volume"),
+                pl.col("close").mean().alias("avg_price")
+            )
+            
+            poc_row = volume_by_bin.sort("total_volume", descending=True).head(1)
+            poc = poc_row["avg_price"][0] if len(poc_row) > 0 else ohlcv["close"].median()
+        
         df = pd.DataFrame(index=ohlcv.index)
         df[f"{self.name}_poc"] = poc
         return df
 
 
-class MovingAverage:
+class SMA(RollingWindowIndicator):
     def __init__(self, name: str, length: int = 20):
-        self.name = name
+        super().__init__(name, length)
         self._length = length
     
-    def calculate(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
-        ma = ohlcv["close"].rolling(window=self._length).mean()
-        return pd.DataFrame({self.name: ma})
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        temp = pl.from_pandas(ohlcv[["close"]])
+        ma = temp.select(
+            pl.col("close").rolling_mean(window_size=self._length).alias(self.name)
+        ).to_pandas()
+        ma.index = ohlcv.index
+        return ma
+
+
+class EMA(RollingWindowIndicator):
+    def __init__(self, name: str, length: int = 20):
+        super().__init__(name, length)
+        self._length = length
     
-    def reset(self) -> None:
-        pass
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        @nb.jit(nopython=True, cache=True)
+        def calculate_ema(prices: np.ndarray, period: int) -> np.ndarray:
+            n = len(prices)
+            ema = np.empty(n)
+            ema[:period-1] = np.nan
+            
+            if n < period:
+                return ema
+            
+            ema[period-1] = np.mean(prices[:period])
+            multiplier = 2.0 / (period + 1)
+            
+            for i in range(period, n):
+                ema[i] = prices[i] * multiplier + ema[i-1] * (1 - multiplier)
+            
+            return ema
+        
+        prices = ohlcv["close"].values.astype(np.float64)
+        ema_values = calculate_ema(prices, self._length)
+        return pd.DataFrame({self.name: ema_values}, index=ohlcv.index)
 
 
-class RSI:
+class RSI(RollingWindowIndicator):
     def __init__(self, name: str, length: int = 14):
-        self.name = name
+        super().__init__(name, length)
         self._length = length
-
-    def calculate(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
-        close = ohlcv["close"]
-        delta = close.diff()
+    
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        @nb.jit(nopython=True, cache=True)
+        def calculate_rsi(prices: np.ndarray, period: int) -> np.ndarray:
+            n = len(prices)
+            rsi = np.empty(n)
+            rsi[:period] = np.nan
+            
+            if n < period + 1:
+                return rsi
+            
+            deltas = np.diff(prices[:period+1])
+            gains = np.where(deltas > 0, deltas, 0.0)
+            losses = np.where(deltas < 0, -deltas, 0.0)
+            
+            avg_gain = np.mean(gains)
+            avg_loss = np.mean(losses)
+            
+            if avg_loss == 0:
+                rsi[period] = 100.0
+            else:
+                rs = avg_gain / avg_loss
+                rsi[period] = 100 - (100 / (1 + rs))
+            
+            for i in range(period + 1, n):
+                delta = prices[i] - prices[i-1]
+                gain = delta if delta > 0 else 0.0
+                loss = -delta if delta < 0 else 0.0
+                
+                avg_gain = (avg_gain * (period - 1) + gain) / period
+                avg_loss = (avg_loss * (period - 1) + loss) / period
+                
+                if avg_loss == 0:
+                    rsi[i] = 100.0
+                else:
+                    rs = avg_gain / avg_loss
+                    rsi[i] = 100 - (100 / (1 + rs))
+            
+            return rsi
         
-        gain = (delta.where(delta > 0, 0)).rolling(window=self._length).mean()
-        loss = (-delta.where(delta < 0, 0)).rolling(window=self._length).mean()
-        
-        rs = gain / loss
-        rsi = 100 - (100 / (1 + rs))
-        
-        return pd.DataFrame({self.name: rsi})
+        prices = ohlcv["close"].values.astype(np.float64)
+        rsi_values = calculate_rsi(prices, self._length)
+        return pd.DataFrame({self.name: rsi_values}, index=ohlcv.index)
 
 
-class MACD:
+class MACD(BaseIndicator):
     def __init__(self, name: str, fast: int = 12, slow: int = 26, signal: int = 9):
-        self.name = name
+        super().__init__(name)
         self._fast = fast
         self._slow = slow
         self._signal = signal
 
-    def calculate(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
-        close = ohlcv["close"]
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        @nb.jit(nopython=True, cache=True)
+        def calculate_ema(prices: np.ndarray, period: int) -> np.ndarray:
+            n = len(prices)
+            ema = np.empty(n)
+            ema[:period-1] = np.nan
+            
+            if n < period:
+                return ema
+            
+            ema[period-1] = np.mean(prices[:period])
+            multiplier = 2.0 / (period + 1)
+            
+            for i in range(period, n):
+                ema[i] = prices[i] * multiplier + ema[i-1] * (1 - multiplier)
+            
+            return ema
         
-        # NOTE: Calculate EMAs
-        ema_fast = close.ewm(span=self._fast, adjust=False).mean()
-        ema_slow = close.ewm(span=self._slow, adjust=False).mean()
+        prices = ohlcv["close"].values.astype(np.float64)
         
-        # NOTE: MACD line
+        ema_fast = calculate_ema(prices, self._fast)
+        ema_slow = calculate_ema(prices, self._slow)
+        
         macd = ema_fast - ema_slow
         
-        # NOTE: Signal line
-        signal = macd.ewm(span=self._signal, adjust=False).mean()
+        macd_clean = macd[~np.isnan(macd)]
+        signal_line = calculate_ema(macd_clean, self._signal)
         
-        # NOTE: MACD histogram
-        histogram = macd - signal
+        signal_aligned = np.full(len(prices), np.nan)
+        valid_start = self._slow - 1 + self._signal - 1
+        if valid_start < len(prices):
+            signal_aligned[valid_start:] = signal_line[:len(prices)-valid_start]
         
-        df = pd.DataFrame({
+        histogram = np.where(
+            np.isnan(macd) | np.isnan(signal_aligned),
+            np.nan,
+            macd - signal_aligned
+        )
+        
+        return pd.DataFrame({
             f"{self.name}": macd,
-            f"{self.name}_signal": signal,
+            f"{self.name}_signal": signal_aligned,
             f"{self.name}_hist": histogram,
-        })
+        }, index=ohlcv.index)
+
+
+class BollingerBands(RollingWindowIndicator):
+    def __init__(self, name: str, length: int = 20, std: float = 2.0):
+        super().__init__(name, length)
+        self._length = length
+        self._std = std
+    
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        @nb.jit(nopython=True, cache=True)
+        def calculate_bb(prices: np.ndarray, period: int, num_std: float) -> tuple:
+            n = len(prices)
+            middle = np.empty(n)
+            upper = np.empty(n)
+            lower = np.empty(n)
+            
+            for i in range(n):
+                if i < period - 1:
+                    middle[i] = np.nan
+                    upper[i] = np.nan
+                    lower[i] = np.nan
+                else:
+                    window = prices[i-period+1:i+1]
+                    mean = np.mean(window)
+                    std = np.std(window)
+                    
+                    middle[i] = mean
+                    upper[i] = mean + std * num_std
+                    lower[i] = mean - std * num_std
+            
+            return middle, upper, lower
         
-        return df
+        prices = ohlcv["close"].values.astype(np.float64)
+        middle, upper, lower = calculate_bb(prices, self._length, self._std)
+        
+        return pd.DataFrame({
+            f"{self.name}_middle": middle,
+            f"{self.name}_upper": upper,
+            f"{self.name}_lower": lower,
+            f"{self.name}_width": upper - lower
+        }, index=ohlcv.index)
 
 
-class IndicatorProcessor:
+class SupportResistance(BaseIndicator):
+    def __init__(self, name: str, lookback: int = 20, min_touches: int = 2, tolerance: float = 0.02):
+        super().__init__(name)
+        self._lookback = lookback
+        self._min_touches = min_touches
+        self._tolerance = tolerance
+    
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        temp = pl.from_pandas(ohlcv[["high", "low"]])
+        
+        resistance = temp.select(
+            pl.col("high").rolling_max(window_size=self._lookback).alias("resistance")
+        ).to_pandas()["resistance"]
+        
+        support = temp.select(
+            pl.col("low").rolling_min(window_size=self._lookback).alias("support")
+        ).to_pandas()["support"]
+        
+        high = ohlcv["high"]
+        low = ohlcv["low"]
+        
+        close_to_resistance = (high >= resistance * (1 - self._tolerance)).rolling(window=self._lookback).sum()
+        close_to_support = (low <= support * (1 + self._tolerance)).rolling(window=self._lookback).sum()
+        
+        return pd.DataFrame({
+            f"{self.name}_resistance": resistance.values,
+            f"{self.name}_support": support.values,
+            f"{self.name}_resistance_touches": close_to_resistance,
+            f"{self.name}_support_touches": close_to_support
+        }, index=ohlcv.index)
+
+
+class FibonacciLevels(BaseIndicator):
+    def __init__(self, name: str, lookback: int = 50):
+        super().__init__(name)
+        self._lookback = lookback
+        self._levels = [0.0, 0.236, 0.382, 0.5, 0.618, 0.786, 1.0]
+    
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        temp = pl.from_pandas(ohlcv[["high", "low"]])
+        
+        high_max = temp.select(
+            pl.col("high").rolling_max(window_size=self._lookback).alias("high_max")
+        ).to_pandas()["high_max"]
+        
+        low_min = temp.select(
+            pl.col("low").rolling_min(window_size=self._lookback).alias("low_min")
+        ).to_pandas()["low_min"]
+        
+        diff = high_max - low_min
+        
+        result = pd.DataFrame(index=ohlcv.index)
+        for level in self._levels:
+            result[f"{self.name}_fib_{int(level*1000)}"] = low_min + (diff * level)
+
+        return result
+
+
+class MAAnalyzer(BaseIndicator):
+    def __init__(self, name: str, periods: List[int]):
+        super().__init__(name)
+        self._periods = sorted(periods)
+    
+    def _compute(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        temp = pl.from_pandas(ohlcv[["close"]])
+        
+        mas = {}
+        for period in self._periods:
+            ma = temp.select(
+                pl.col("close").rolling_mean(window_size=period).alias(f"ma_{period}")
+            ).to_pandas()[f"ma_{period}"]
+            mas[period] = ma
+        
+        result = pd.DataFrame(index=ohlcv.index)
+        
+        for period, ma in mas.items():
+            result[f"{self.name}_ma{period}"] = ma
+        
+        if len(self._periods) >= 2:
+            for i in range(len(self._periods) - 1):
+                fast_period = self._periods[i]
+                slow_period = self._periods[i + 1]
+                result[f"{self.name}_cross_{fast_period}_{slow_period}"] = (
+                    mas[fast_period] > mas[slow_period]
+                ).astype(int)
+        
+        if len(self._periods) >= 2:
+            ma_df = pd.DataFrame(mas, index=ohlcv.index)
+            min_ma = ma_df.min(axis=1)
+            max_ma = ma_df.max(axis=1)
+            result[f"{self.name}_spread"] = (max_ma - min_ma) / ohlcv["close"] * 100
+        
+        return result
+
+
+class IndicatorProcessor:    
     def __init__(self):
         self._indicators: List[TechnicalIndicator] = []
 
@@ -139,8 +386,16 @@ class IndicatorProcessor:
         self._indicators.append(indicator)
 
     def process(self, ohlcv: pd.DataFrame) -> Dict[str, pd.DataFrame]:
-        indicator_dfs = [indicator.calculate(
-            ohlcv) for indicator in self._indicators]
+        indicator_dfs = []
+        
+        for indicator in self._indicators:
+            try:
+                result = indicator.calculate(ohlcv)
+                indicator_dfs.append(result)
+            except Exception as e:
+                print(f"Error calculating {indicator.name}: {e}")
+                continue
+        
         ti_df = pd.concat(indicator_dfs, axis=1) if indicator_dfs else pd.DataFrame(
             index=ohlcv.index)
         return {"ohlcv": ohlcv, "indicators": ti_df}


### PR DESCRIPTION
● 1. SMA와 EMA가 다른 이유:

  SMA (Simple Moving Average): 단순 평균 → polars의 rolling_mean이 빠름
  EMA (Exponential Moving Average): 지수 가중 평균 → 이전 값에 의존하는 순차 계산이라 numba 필요

  # SMA: 각 window 독립적
  window[i] = mean(prices[i-20:i])  # 병렬 처리 가능

  # EMA: 이전 EMA 값 필요  
  ema[i] = price[i] * 0.1 + ema[i-1] * 0.9  # 순차적으로만 가능

  2. 내부 함수로 둔 이유:

  # 내부 함수 방식 (현재)
  def _compute(self, ohlcv):
      @nb.jit(nopython=True)
      def calculate_ema(prices, period):
          # numba 코드

      return calculate_ema(prices, self._length)

  # 직접 사용하면 안 되는 이유
  @nb.jit(nopython=True)  # 에러! self를 numba가 이해 못함
  def _compute(self, ohlcv):
      # self._length 접근 불가

  numba는 순수 numpy만 이해하므로 클래스 메서드(self 포함)를 직접 컴파일할 수 없습니다.